### PR TITLE
Add KSP and Used Libs Toml

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+PersonalNotesApp

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="21" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+    <option name="applicationTheme" value="default" />
+    <option name="iconsTheme" value="default" />
+    <option name="button1Title" value="" />
+    <option name="button1Url" value="" />
+    <option name="button2Title" value="" />
+    <option name="button2Url" value="" />
+    <option name="customApplicationId" value="" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,8 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    
-    id ("com.google.devtools.ksp")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -53,6 +52,9 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -60,18 +62,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-
-    // Room
-    val room_version = "2.6.1" // Use the latest stable version
-
-    implementation ("androidx.room:room-runtime:$room_version")
-    implementation ("androidx.room:room-ktx:$room_version")
-
-
-
-
-
-
-
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,9 +10,14 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 navigationFragmentKtx = "2.9.3"
 navigationUiKtx = "2.9.3"
+room = "2.7.2"
+ksp = "2.2.0-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -33,4 +38,4 @@ androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
This pull request primarily updates project configuration files and refines dependency management for the Android app. The main changes include adding and updating IDE configuration files, improving how Room database dependencies are managed, and switching to a more consistent plugin alias for KSP. These changes enhance project setup, make dependency management cleaner, and improve compatibility with IDE tooling.

**Project configuration and IDE setup:**

* Added several new `.idea` configuration files for project name, compiler settings, deployment target selection, Discord integration, VCS mappings, and App Insights settings to support better IDE integration and project management. [[1]](diffhunk://#diff-4f415fa58f590012af61c36587e07700fb276d8c56773174f5fae9c70f3ccdb9R1) [[2]](diffhunk://#diff-2bb695a627709c0ba8d2645880396ff81d5f9f7ce16b2577cd9df1ea6f3b04b5R1-R6) [[3]](diffhunk://#diff-48ade0dcc88e13ad2f209104182451574719123469c44aa4bb0558302d2ee7fbR1-R10) [[4]](diffhunk://#diff-036da77e0e4b2f4e042049d9b20f5cfc4a347bc1e01391bd3bf3bc8ae4601768R1-R14) [[5]](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR1-R6) [[6]](diffhunk://#diff-9642951fae558e4e7259e05cf617e94bbf2e776729eb7124436da50cb25af415R1-R26)

**Dependency and plugin management:**

* Updated `gradle/libs.versions.toml` to define Room and KSP versions and add corresponding library entries for Room and KSP dependencies, enabling centralized version management.
* Replaced manual Room version management in `app/build.gradle.kts` with version catalog aliases for Room dependencies, and removed redundant manual Room version declarations for cleaner dependency handling.
* Switched the KSP plugin in `app/build.gradle.kts` from direct ID usage to the version catalog alias for consistency with other plugins.
* Added a version catalog alias for the KSP plugin in `gradle/libs.versions.toml` for improved plugin version management.